### PR TITLE
Port to version 1.169 of Nautilus Trader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,4 +257,4 @@ cython_debug/
 .idea
 
 #20220617
-20220617/demo/catalog
+20220617/demo/catalog/data

--- a/20220617/demo/backtest.py
+++ b/20220617/demo/backtest.py
@@ -1,9 +1,9 @@
 import pathlib
 from typing import Tuple
 
-from nautilus_trader.backtest.engine import CacheConfig
 from nautilus_trader.backtest.node import BacktestNode
 from nautilus_trader.config import (
+    CacheConfig,
     BacktestDataConfig,
     BacktestEngineConfig,
     BacktestRunConfig,
@@ -60,7 +60,7 @@ def main(
         bypass_logging=bypass_logging,
         log_level=log_level,
         streaming=StreamingConfig(catalog_path=str(catalog.path)) if persistence else None,
-        risk_engine=RiskEngineConfig(max_order_rate="1000/00:00:01"),  # type: ignore
+        risk_engine=RiskEngineConfig(max_order_submit_rate="1000/00:00:01"),  # type: ignore
         strategies=[strategy],
         actors=[prediction],
     )

--- a/20220617/demo/live.py
+++ b/20220617/demo/live.py
@@ -1,6 +1,10 @@
-from nautilus_trader.adapters.interactive_brokers.config import InteractiveBrokersDataClientConfig
+from nautilus_trader.adapters.interactive_brokers.config import (
+    InteractiveBrokersDataClientConfig,
+    InteractiveBrokersExecClientConfig
+)
 from nautilus_trader.adapters.interactive_brokers.factories import (
     InteractiveBrokersLiveDataClientFactory,
+    InteractiveBrokersLiveExecClientFactory
 )
 from nautilus_trader.config import InstrumentProviderConfig, TradingNodeConfig
 from nautilus_trader.live.node import TradingNode
@@ -13,7 +17,11 @@ config_node = TradingNodeConfig(
     log_level="DEBUG",
     data_clients={
         "IB": InteractiveBrokersDataClientConfig(
+            trading_mode="paper",
+            start_gateway=False,
+            read_only_api=False,
             gateway_host="127.0.0.1",
+            gateway_port=4002,
             instrument_provider=InstrumentProviderConfig(
                 load_all=True,
                 filters=tuple(
@@ -27,9 +35,15 @@ config_node = TradingNodeConfig(
             ),
         ),
     },
-    # exec_clients={
-    #     "IB": InteractiveBrokersExecClientConfig(),
-    # },
+    exec_clients={
+        "IB": InteractiveBrokersExecClientConfig(
+            trading_mode="paper",
+            start_gateway=False,
+            read_only_api=False,
+            gateway_host="127.0.0.1",
+            gateway_port=4002,
+        ),
+    },
     timeout_connection=90.0,
     timeout_reconciliation=5.0,
     timeout_portfolio=5.0,
@@ -53,12 +67,12 @@ node.trader.add_strategy(strategy)
 
 # Register your client factories with the node (can take user defined factories)
 node.add_data_client_factory("IB", InteractiveBrokersLiveDataClientFactory)
-# node.add_exec_client_factory("IB", InteractiveBrokersLiveExecutionClientFactory)
+node.add_exec_client_factory("IB", InteractiveBrokersLiveExecClientFactory)
 node.build()
 
 # Stop and dispose of the node with SIGINT/CTRL+C
 if __name__ == "__main__":
     try:
-        node.start()
+        node.run()
     finally:
         node.dispose()

--- a/20220617/demo/strategy.py
+++ b/20220617/demo/strategy.py
@@ -9,7 +9,6 @@ from nautilus_trader.config import StrategyConfig
 from nautilus_trader.core.data import Data
 from nautilus_trader.core.datetime import unix_nanos_to_dt
 from nautilus_trader.core.message import Event
-from nautilus_trader.model.c_enums.order_side import OrderSideParser
 from nautilus_trader.model.data.bar import Bar, BarSpecification
 from nautilus_trader.model.data.base import DataType
 from nautilus_trader.model.enums import OrderSide, PositionSide, TimeInForce
@@ -34,7 +33,6 @@ class PairTraderConfig(StrategyConfig):
     trade_width_std_dev: float = 2.5
     bar_spec: str = "10-SECOND-LAST"
     ib_long_short_margin_requirement = (0.25 + 0.17) / 2.0
-
 
 class PairTrader(Strategy):
     def __init__(self, config: PairTraderConfig):
@@ -125,14 +123,14 @@ class PairTrader(Strategy):
                 max_volume = int(self.config.notional_trade_size_usd / market_right)
                 capped_volume = self._cap_volume(instrument_id=self.target_id, max_quantity=max_volume)
                 price = self.prediction - self._current_required_edge
-                self._log.debug(f"{OrderSideParser.to_str_py(side)} {max_volume=} {capped_volume=} {price=}")
+                self._log.debug(f"{side} {max_volume=} {capped_volume=} {price=}")
             elif self._current_edge < -self._current_required_edge:
                 # Our theoretical price is below the market; we want to sell
                 side = OrderSide.SELL
                 max_volume = int(self.config.notional_trade_size_usd / market_right)
                 capped_volume = self._cap_volume(instrument_id=self.target_id, max_quantity=max_volume)
                 price = self.prediction + self._current_required_edge
-                self._log.debug(f"{OrderSideParser.to_str_py(side)} {max_volume=} {capped_volume=} {price=}")
+                self._log.debug(f"{side} {max_volume=} {capped_volume=} {price=}")
             else:
                 return
             if capped_volume == 0:
@@ -141,7 +139,7 @@ class PairTrader(Strategy):
                     self.cancel_order(order=order)
                 return
             self._log.info(
-                f"Entry opportunity: {OrderSideParser.to_str_py(side)} market={market_right}, "
+                f"Entry opportunity: {side} market={market_right}, "
                 f"theo={self.prediction:0.3f} {capped_volume=} ({self._current_edge=:0.3f}, "
                 f"{self._current_required_edge=:0.3f})",
                 color=LogColor.GREEN,

--- a/20220617/pyproject.toml
+++ b/20220617/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Bradley McElroy <bradley.mcelroy@live.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.11"
+python = ">=3.9,<=3.11"
 nautilus-trader = { version = "^1.160.0", extras=["ib"] }
 
 invoke = "^1.7.1"


### PR DESCRIPTION
Port to version 1.169 of Nautilus Trader
Enable use with Python 3.11
Create catalog folder to avoid errors extracting data file. (perhaps better way to do this)

Not sure if you want to merge this or just keep it in PRs for reference.

I believe I have this right, but no guarantees. :-)